### PR TITLE
Limits document return to distinct ids

### DIFF
--- a/src/document_store.py
+++ b/src/document_store.py
@@ -66,14 +66,11 @@ class DocumentStore:
         )
 
     def get_all_documents(self) -> list[UniqueDocument]:
-        all_documents: GetResult = self.collection.get(include=['metadatas'])
+        all_documents: GetResult = self.collection.get(include=['metadatas'], where={"chunk_idx": 0})
         all_metadatas: list[Mapping] = all_documents['metadatas']
         unique_documents: list[UniqueDocument] = []
-        inserted_ids: list = []
         for metadata in all_metadatas:
-            if inserted_ids.count(metadata['uuid']) == 0:
-                unique_documents.append(UniqueDocument(uuid=metadata['uuid'], source=metadata['source']))
-                inserted_ids.append(metadata['uuid'])
+            unique_documents.append(UniqueDocument(uuid=metadata['uuid'], source=metadata['source']))
         return unique_documents
 
     def delete_documents(self, uuids: List[str]):

--- a/src/document_store.py
+++ b/src/document_store.py
@@ -69,8 +69,11 @@ class DocumentStore:
         all_documents: GetResult = self.collection.get(include=['metadatas'])
         all_metadatas: list[Mapping] = all_documents['metadatas']
         unique_documents: list[UniqueDocument] = []
+        inserted_ids: list = []
         for metadata in all_metadatas:
-            unique_documents.append(UniqueDocument(uuid=metadata['uuid'], source=metadata['source']))
+            if inserted_ids.count(metadata['uuid']) == 0:
+                unique_documents.append(UniqueDocument(uuid=metadata['uuid'], source=metadata['source']))
+                inserted_ids.append(metadata['uuid'])
         return unique_documents
 
     def delete_documents(self, uuids: List[str]):

--- a/src/ingest.py
+++ b/src/ingest.py
@@ -45,9 +45,10 @@ def load_file(file_path) -> List[Document]:
         return UnstructuredFileLoader(file_path).load()
 
 
-def update_metadata(file_name: str, doc_uuid: str, metadata: dict) -> dict:
+def update_metadata(file_name: str, doc_uuid: str, idx: int, metadata: dict) -> dict:
     metadata['source'] = file_name
     metadata['uuid'] = doc_uuid
+    metadata['chunk_idx'] = idx
     return metadata
 
 
@@ -70,7 +71,8 @@ class Ingest:
             texts: list[Document] = text_splitter.split_documents(data)
             contents: list[str] = [d.page_content for d in texts]
             doc_uuid: str = str(uuid.uuid4())
-            all_metadata: list[dict] = [update_metadata(file_name, doc_uuid, d.metadata) for d in texts]
+            all_metadata: list[dict] = [update_metadata(file_name, doc_uuid, idx, d.metadata)
+                                        for idx, d in enumerate(texts)]
             ids: list[str] = get_uuids_for_document_texts(texts)
             self.collection.add(documents=contents, metadatas=all_metadata, ids=ids)
             # split and load into vector db


### PR DESCRIPTION
The query to list all documents currently returns all documents and their chunks. This fix only returns one result per doc regardless of how many chunks are in the vectordb.

Every chunk in a document now includes an index to allow additional filtering. The index is used to prevent a full table scan when searching for individual chunks.